### PR TITLE
chore: Update .browserslistrc to exclude unsupported Safari versions

### DIFF
--- a/src/client/.browserslistrc
+++ b/src/client/.browserslistrc
@@ -15,3 +15,4 @@ last 2 Safari major versions
 last 2 iOS major versions
 Firefox ESR
 not IE 11 # Angular supports IE 11 only as an opt-in. To opt-in, remove the 'not' prefix on this line.
+not safari 15.2-15.3 # Safari 15.2 and 15.3 are not supported. It causes a error when deploying to production.


### PR DESCRIPTION
## Description

The production build was failing on the static web app. The issue reported is that there are unsupported versions of Safari for the cssloader, ivy complier  and polyfills.

This is likely to do with the versions of the packages we're using and that newer versions of the browsers have been released.

./node_modules/css-loader/dist/runtime/noSourceMaps.js - Error: Module build failed (from ./node_modules/@ngtools/webpack/src/ivy/index.js):
Transform failed with 1 error:
error: Invalid version: "15.2-15.3"

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

We can only test this to determine if the live deployment works. 

aside - I need to upgrade the solutions and are in the middle of open sourcing the project to gain some support in this so that issues like this can be resolved by the community

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules